### PR TITLE
Software table

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -105,3 +105,25 @@
     year={2020},
     publisher={Oxford University Press}
 }
+
+@InCollection{kelleher2020coalescent,
+    author={Kelleher, Jerome and Lohse, Konrad},
+    editor={Dutheil, Julien Y.},
+    title={Coalescent Simulation with msprime},
+    bookTitle={Statistical Population Genomics},
+    year={2020},
+    publisher={Springer US},
+    address={New York, NY},
+    pages={191--230},
+}
+
+@article{hudson2002generating,
+    author ={Richard R. Hudson},
+    title = {Generating samples under a {Wright-Fisher} neutral model of genetic variation}, 
+    year = {2002},
+    journal = {Bioinformatics},
+    volume = {18},
+    number = {2},
+    pages = {337--338},
+}
+

--- a/paper.tex
+++ b/paper.tex
@@ -138,45 +138,59 @@ fit to data, e.g. \moments\ or \dadi]].
 \end{itemize}
 
 
-\begin{table}
-\begin{center}
-\begin{tabular}{llr}
-\msprime & \citep{kelleher2016efficient} & Coalescent simulator \\
-\stdpopsim & \citep{adrion2020community} & Library of standardised simulations \\
-\fwdpy & \citep{thornton2014c++} & Forward-time simulator \\
-\moments & \citep{jouganous2017inferring,ragsdale2019models}
-    & Demographic inference \\
-\dadi & \citep{gutenkunst2009inferring}  & Demographic inference \\
-\gadma & \citep{noskova2020gadma}  & Demographic inference \\
-\end{tabular}
-\end{center}
-\caption{Software supporting Demes as an input or output format.
-\jkcomment{This is a very rough first pass. It's not clear that a table is the
-right format for presenting this information, maybe a description
-list would be better instead?}}
-\end{table}
+% \begin{table}
+% \begin{center}
+% \begin{tabular}{llr}
+% \msprime & \citep{kelleher2016efficient} & Coalescent simulator \\
+% \stdpopsim & \citep{adrion2020community} & Library of standardised simulations \\
+% \fwdpy & \citep{thornton2014c++} & Forward-time simulator \\
+% \moments & \citep{jouganous2017inferring,ragsdale2019models}
+%     & Demographic inference \\
+% \dadi & \citep{gutenkunst2009inferring}  & Demographic inference \\
+% \gadma & \citep{noskova2020gadma}  & Demographic inference \\
+% \end{tabular}
+% \end{center}
+% \caption{Software supporting Demes as an input or output format.
+% \jkcomment{This is a very rough first pass. It's not clear that a table is the
+% right format for presenting this information, maybe a description
+% list would be better instead?}}
+% \end{table}
 
-\section*{Extensions and future directions}
+\subsection*{Software support for Demes}
 
-\subsection*{Software support for \demes}
-\aprcomment{at time of publication. TBD...}
-\begin{itemize}
-    \item \msprime: coalescent simulation \citep{kelleher2016efficient}
-    \item \stdpopsim: a collection of maintained species and demographic models,
-        which includes a large number of models specified using \demes
-        \citep{adrion2020community}
-    \item \fwdpy: forward-time Wright-Fisher simulation \citep{thornton2014c++}
-    \item \moments: compute expected diversity statistics (SFS, LD) and perform
+\begin{description}
+    \item[demes-python] A Python library for loading, saving, and working with
+        Demes models. Includes conversion utilities for existing formats
+        demographic model descriptions such as
+        \texttt{ms}~\citep{hudson2002generating}.
+    \item[demes-c] A C library for parsing Demes YAML descriptions.
+    \item[demesdraw] A Python library for visualising Demes models
+     (\url{https://github.com/grahamgower/demesdraw.git}).
+\end{description}
+
+
+\subsection*{Software implementing Demes}
+At the time of writing, the following software implements the Demes
+specification, as a supported input or output format.
+
+\begin{description}
+    \item[msprime:] Coalescent simulation
+        \citep{kelleher2016efficient,kelleher2020coalescent}
+    \item[stdpopsim:] A collection of community empirical data for species
+        and demographic models specified in Demes format~\citep{adrion2020community}.
+    \item[fwdpy11:] forward-time Wright-Fisher simulation \citep{thornton2014c++}
+    \item[moments:] compute expected diversity statistics (SFS, LD) and perform
         demographic inference using summary statistics
-        \citep{jouganous2017inferring,ragsdale2019models}
-    \item \dadi: compute the expected SFS and perform demographic inference using
-        summary statistics \citep{gutenkunst2009inferring}
-\end{itemize}
+        \citep{jouganous2017inferring,ragsdale2019models}.
+    \item[$\partial$a$\partial$i] compute the expected SFS and
+        perform demographic inference using
+        summary statistics \citep{gutenkunst2009inferring}.
+    \item[GADMA] Demographic inference \citep{noskova2020gadma}.
+\end{description}
 
 \subsection*{Other stuff...}
 
 \begin{itemize}
-    \item \texttt{demesdraw} (\url{https://github.com/grahamgower/demesdraw.git})
     \item General framework for inference (have been working on that over in \moments,
         and perhaps it could be generalized to work with any simulation engine
     \item Defining distributions of parameter values, perhaps?

--- a/paper.tex
+++ b/paper.tex
@@ -3,6 +3,7 @@
 \usepackage{fullpage}
 \usepackage{authblk}
 \usepackage{graphicx}
+\usepackage{booktabs}
 
 \usepackage[newfloat]{minted}
 \usepackage{tcolorbox}
@@ -137,56 +138,67 @@ fit to data, e.g. \moments\ or \dadi]].
     \item Designed to be programatically read by simulation software backends
 \end{itemize}
 
+% Add a bit more space between rows.
+\renewcommand{\arraystretch}{1.5}
+\begin{table}
+\begin{center}
+\begin{tabular}{lp{12cm}}
+\toprule
+\multicolumn{2}{l}{Software infrastructure}\\
+\midrule
+\texttt{demes-python} &
+    A Python library for loading, saving, and working with
+    Demes models. Includes conversion utilities for existing formats
+    demographic model descriptions such as
+    \texttt{ms}~\citep{hudson2002generating}.\\
 
-% \begin{table}
-% \begin{center}
-% \begin{tabular}{llr}
-% \msprime & \citep{kelleher2016efficient} & Coalescent simulator \\
-% \stdpopsim & \citep{adrion2020community} & Library of standardised simulations \\
-% \fwdpy & \citep{thornton2014c++} & Forward-time simulator \\
-% \moments & \citep{jouganous2017inferring,ragsdale2019models}
-%     & Demographic inference \\
-% \dadi & \citep{gutenkunst2009inferring}  & Demographic inference \\
-% \gadma & \citep{noskova2020gadma}  & Demographic inference \\
-% \end{tabular}
-% \end{center}
-% \caption{Software supporting Demes as an input or output format.
-% \jkcomment{This is a very rough first pass. It's not clear that a table is the
-% right format for presenting this information, maybe a description
-% list would be better instead?}}
-% \end{table}
+\texttt{demes-c} &
+    A C library for parsing Demes YAML descriptions.
+    (\url{https://github.com/grahamgower/demes-c.git}). \\
 
-\subsection*{Software support for Demes}
+\texttt{demesdraw} &
+    A Python library for visualising Demes models
+    (\url{https://github.com/grahamgower/demesdraw.git}). \\
 
-\begin{description}
-    \item[demes-python] A Python library for loading, saving, and working with
-        Demes models. Includes conversion utilities for existing formats
-        demographic model descriptions such as
-        \texttt{ms}~\citep{hudson2002generating}.
-    \item[demes-c] A C library for parsing Demes YAML descriptions.
-    \item[demesdraw] A Python library for visualising Demes models
-     (\url{https://github.com/grahamgower/demesdraw.git}).
-\end{description}
+\midrule
+\multicolumn{2}{l}{Methods using Demes as input/output format}\\
+\midrule
 
+% TOOL AUTHORS: please add a row to this table to summarise what the software
+% does, and how it implements demes.
 
-\subsection*{Software implementing Demes}
-At the time of writing, the following software implements the Demes
-specification, as a supported input or output format.
+\dadi &
+    Summary of what dadi does and how it implements Demes~\citep{gutenkunst2009inferring}.
+    \\
 
-\begin{description}
-    \item[msprime:] Coalescent simulation
-        \citep{kelleher2016efficient,kelleher2020coalescent}
-    \item[stdpopsim:] A collection of community empirical data for species
-        and demographic models specified in Demes format~\citep{adrion2020community}.
-    \item[fwdpy11:] forward-time Wright-Fisher simulation \citep{thornton2014c++}
-    \item[moments:] compute expected diversity statistics (SFS, LD) and perform
-        demographic inference using summary statistics
-        \citep{jouganous2017inferring,ragsdale2019models}.
-    \item[$\partial$a$\partial$i] compute the expected SFS and
-        perform demographic inference using
-        summary statistics \citep{gutenkunst2009inferring}.
-    \item[GADMA] Demographic inference \citep{noskova2020gadma}.
-\end{description}
+\fwdpy &
+    Forward-time Wright-Fisher simulation \citep{thornton2014c++}\\
+
+\gadma &
+    Demographic inference \citep{noskova2020gadma}.\\
+
+\moments &
+    Compute expected diversity statistics (SFS, LD) and perform
+    demographic inference using summary statistics
+    \citep{jouganous2017inferring,ragsdale2019models}.\\
+
+\msprime &
+    Coalescent simulation of Demes models, including command line
+    interface~\citep{kelleher2016efficient,kelleher2020coalescent}.\\
+
+\stdpopsim &
+    A collection of community empirical data for species
+    and demographic models specified in Demes
+    format~\citep{adrion2020community}.\\
+
+\bottomrule
+\end{tabular}
+\end{center}
+\caption{Software support for Demes. We have included software infrastructure developed
+for working with Demes models (parsing, validation, visualisation, etc)
+as well as all known downstream software that implements the specification,
+at the time of writing.}
+\end{table}
 
 \subsection*{Other stuff...}
 
@@ -198,11 +210,5 @@ specification, as a supported input or output format.
 
 \bibliographystyle{plainnat}
 \bibliography{paper}
-
-\section*{Appendix}
-
-\aprcomment{Perhaps and example of a many-population model, and API to simulate using
-\msprime, \fwdpy, and \moments?}
-
 
 \end{document}

--- a/paper.tex
+++ b/paper.tex
@@ -148,7 +148,7 @@ fit to data, e.g. \moments\ or \dadi]].
 \midrule
 \texttt{demes-python} &
     A Python library for loading, saving, and working with
-    Demes models. Includes conversion utilities for existing formats
+    Demes models. Includes conversion utilities for existing
     demographic model descriptions such as
     \texttt{ms}~\citep{hudson2002generating}.\\
 
@@ -187,7 +187,7 @@ fit to data, e.g. \moments\ or \dadi]].
     interface~\citep{kelleher2016efficient,kelleher2020coalescent}.\\
 
 \stdpopsim &
-    A collection of community empirical data for species
+    A community-maintained collection of empirical data for species
     and demographic models specified in Demes
     format~\citep{adrion2020community}.\\
 


### PR DESCRIPTION
Another pass at the software table. Looks like:

![demes-table](https://user-images.githubusercontent.com/2664569/121925258-a4189500-cd34-11eb-811f-92f9621b36a6.png)

We can tidy it up a bit, but I think the format is good. It's a nice concise way of getting across the current level of support.