### PR TITLE
Trim out spec-like details from popgen model.

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -228,7 +228,7 @@ In Demes, demographic models consist of one or more interacting populations (or
 ``demes"; to avoid confusion with the name of the specification itself we will
 use the term ``population'' in this discussion, in the understanding that the
 terms are interchangeable for our purposes). Populations are defined as a
-collection of exchangable individuals that exist for a specified period of
+collection of exchangeable individuals that exist for a specified period of
 time, following a well-defined set of rules regarding population sizes, mating
 systems, etc. Ancestor/descendant relationships between populations can be
 defined, as well as continuous or instantaneous migration between coexisting
@@ -238,17 +238,26 @@ Population and event times are written as units in the past, so that time zero
 corresponds to the final generation or ``now'', and event times in the past are
 values greater than zero with larger values for events that occur in the more
 distant past. While a natural specification for time units is in generations,
-other time units are allowed, such as years. In the case that the time units
-are not given in generations, the generation time must also be specified so
-that times can be converted into generations. In general, as time flows from
-the past to the present, populations, epochs, and migration events should be
-specified in their order of appearance, so that their times are in descending
-order.
+other time units are allowed, such as years.
+\jkcomment{Why did we choose time to flow in this direction?}
 
-Models include one or more populations that have sizes greater than zero for
-the duration of their existences, and population sizes are given as the number
-of individuals. A population must exist for some duration of time greater than
-zero, so that its start time must be larger than its end time. It may have one
+Population sizes are given as the number of individuals.
+\jkcomment{As opposed to genomes. Why did we do this?}
+Sizes and mating system details are specified for each population within
+epochs. Epochs are contiguous time intervals that define
+the existence interval of the population. Each epoch specifies the population size
+over that interval, which can be a constant value or function defined by start
+and end sizes that must remain positive.
+
+Within a population, individuals are assumed to be exchangeable, but
+there are also parameters for nonrandom mating, such as selfing or cloning rates,
+which give the probability that offspring are generated from one generation to
+the next by self-fertilization or cloning of an individual
+\textbf{need to precisely specify once this is determined}.
+\jkcomment{More detail here. Also, why only selfing and cloning, why not selection
+coefficients and whatnot?}
+
+A population may have one
 or more ancestors, which are other populations that exist at the population's
 start time. If one ancestor is specified, the first generation is constructed
 by randomly sampling parents from the ancestral population to contribute to
@@ -256,37 +265,18 @@ offspring in the newly generated population. If more than one ancestor is
 specified, the proportions of ancestry from each contributing population must
 be provided, and those proportions must sum to one. In this case, parents are
 chosen randomly from each ancestral population with probability given by those
-proportions. If no ancestors are specified, the population is assumed to have
-start time equal to infinity, as individuals are not assumed to spontaneously
-spring into existence.
-
-Within populations, population sizes and mating systems are specified within
-epochs. Epochs are non-overlapping intervals of time that cover the entire
-existence interval of the population. Each epoch specifies the population size
-over that interval, which can be a constant value or function defined by start
-and end sizes that must remain positive.  If an epoch has a start time of
-infinity, the population size for that epoch must be constant. Epochs can also
-specify parameters for nonrandom mating, such as selfing or cloning rates,
-which give the probability that offspring are generated from one generation to
-the next by self-fertilization or cloning of an individual \textbf{need to
-precisely specify once this is determined}.
+proportions.
 
 Finally, individuals in a population may have parents from a different
 population through migrations. These can be defined as continuous migration
 rates over time intervals for which populations coexist or through
 instantaneous (or pulse) migration events at a given time. Continuous migration
 rates are defined as the probability that parents in the ``destination''
-population are chosen from the ``source'' population.  Migration rates are thus
-per generation and must be less than one. Furthermore, if more than one source
-population have continuous migration into the same destination population, the
-sum of those migration rates must also be less than one, as rates define
-probabilities. The probability that parents come from the same population is
-just one minus the sum of incoming migration rates. On the other hand, pulse
-migration events specify the instantaeous replacement of a given fraction of
+population are chosen from the ``source'' population.
+On the other hand, pulse
+migration events specify the instantaneous replacement of a given fraction of
 individuals in a destination population by individuals with parents from a
-source population.  The fraction must be between zero and one, and if more than
-one pulse occurs at the same time, those replacement events are applied
-sequentially in the order that they are specified in the model.
+source population.
 
 \begin{figure}
 \begin{minipage}{0.48\textwidth}


### PR DESCRIPTION
A quick editing pass to remove details that belong in the spec and to add some comments pointing out where I think we need more rationale behind the chosen approach.