### PR TITLE
Remove stdpopsim from software table

### DIFF
--- a/software-table.tex
+++ b/software-table.tex
@@ -42,11 +42,4 @@
     Coalescent simulation of Demes models, including command line
     interface~\citep{kelleher2016efficient,kelleher2020coalescent,baumdicker2021-iu}.\\
 
-\stdpopsim &
-    A community-maintained collection of empirical data for species
-    and demographic models specified in Demes
-    format~\citep{adrion2020community}.
-    \ggcomment{stdpopsim doesn't yet have Demes support}
-    \\
-
 \bottomrule   


### PR DESCRIPTION
Stdpopsim won't have the catalog converted to Demes in the immediate future, so removing it from the list of using software.

We would like to do the conversion, we just don't want to block getting the paper out on this because there's a lot going on in stdpopsim at the moment.