### PR TITLE
Move Fig A1A and B into main text

### DIFF
--- a/models/IM-resolved.yaml
+++ b/models/IM-resolved.yaml
@@ -3,51 +3,57 @@ time_units: generations
 generation_time: 1
 doi: []
 demes:
-- name: A
-  description: The ancestral deme
-  start_time: .inf
-  ancestors: []
-  proportions: []
-  epochs:
-  - end_time: 100
-    start_size: 1000
-    end_size: 1000
-    size_function: constant
-    selfing_rate: 0
-    cloning_rate: 0
-- name: X
-  description: First descendant deme.
-  start_time: 100
-  ancestors: [A]
-  proportions: [1]
-  epochs:
-  - end_time: 0
-    start_size: 1000
-    end_size: 1000
-    size_function: constant
-    selfing_rate: 0
-    cloning_rate: 0
-- name: Y
-  description: Second descendant deme.
-  start_time: 100
-  ancestors: [A]
-  proportions: [1]
-  epochs:
-  - end_time: 50
-    start_size: 1000
-    end_size: 1000
-    size_function: constant
-    selfing_rate: 0
-    cloning_rate: 0
-  - end_time: 0
-    start_size: 1000
-    end_size: 3000
-    size_function: exponential
-    selfing_rate: 0
-    cloning_rate: 0
+  - name: A
+    description: The ancestral deme
+    start_time: .inf
+    ancestors: []
+    proportions: []
+    epochs:
+      - end_time: 100
+        start_size: 1000
+        end_size: 1000
+        size_function: constant
+        selfing_rate: 0
+        cloning_rate: 0
+  - name: X
+    description: First descendant deme.
+    start_time: 100
+    ancestors: [A]
+    proportions: [1]
+    epochs:
+      - end_time: 0
+        start_size: 1000
+        end_size: 1000
+        size_function: constant
+        selfing_rate: 0
+        cloning_rate: 0
+  - name: Y
+    description: Second descendant deme.
+    start_time: 100
+    ancestors: [A]
+    proportions: [1]
+    epochs:
+      - end_time: 50
+        start_size: 1000
+        end_size: 1000
+        size_function: constant
+        selfing_rate: 0
+        cloning_rate: 0
+      - end_time: 0
+        start_size: 1000
+        end_size: 3000
+        size_function: exponential
+        selfing_rate: 0
+        cloning_rate: 0
 migrations:
-- {source: X, dest: Y, start_time: 100, end_time: 0,
-  rate: 0.0001}
-- {source: Y, dest: X, start_time: 100, end_time: 0,
-  rate: 0.0001}
+  - source: X
+    dest: Y
+    start_time: 100
+    end_time: 0
+    rate: 0.0001
+  - source: Y
+    dest: X
+    start_time: 100
+    end_time: 0
+    rate: 0.0001
 pulses: []

--- a/models/IM.yaml
+++ b/models/IM.yaml
@@ -3,7 +3,8 @@ description:
   Two-deme isolation-with-migration model.
 time_units: generations
 defaults:
-  epoch: {start_size: 1000}
+  epoch:
+    start_size: 1000
 demes:
   - name: A
     description: The ancestral deme
@@ -16,7 +17,8 @@ demes:
     description: Second descendant deme.
     ancestors: [A]
     epochs:
-      - {end_time: 50}
-      - {end_size: 3000}
+      - end_time: 50
+      - end_size: 3000
 migrations:
-  - {demes: [X, Y], rate: 1e-4}
+  - demes: [X, Y]
+    rate: 1e-4

--- a/paper.tex
+++ b/paper.tex
@@ -290,10 +290,45 @@ features of the model (such as time units and generation times),
 populations (as ``demes'') and their existence intervals (as ``epochs''),
 and gene flow between populations
 (as continuous ``migrations'' or instantaneous ``pulse'' events)
-(e.g., Figures~\ref{fig:showcase}~and~\ref{fig:IM}).
+(e.g., Figures~\ref{fig:IM}~and~\ref{fig:showcase}).
 The HDM encourages human understanding by avoiding
 redundancy in the description where possible and by providing a mechanism for
 specifying default values that are inherited hierarchically.
+
+\subsection*{Example: an isolation with migration model}
+
+\ggcomment{Add some text here describing the YAML in Figure \ref{fig:IM}.}
+
+\begin{figure}[h!]
+    \begin{minipage}{0.45\textwidth}
+    \begin{subfigure}{\textwidth}
+    \caption{}
+        \begin{tcolorbox}[equal height group=IM]
+            \inputminted[fontsize=\scriptsize,numbersep=5pt]{yaml}{models/IM.yaml}
+        \end{tcolorbox}
+    \end{subfigure}
+    \end{minipage}\hfill%
+%
+    \begin{minipage}{0.50\textwidth}
+    \begin{subfigure}{\textwidth}
+    \caption{}
+        \begin{tcolorbox}[equal height group=IM, boxsep=0pt]
+            \includegraphics[width=\textwidth]{fig/IM}
+        \end{tcolorbox}
+    \end{subfigure}
+    \end{minipage}\\
+
+    \caption{
+        \label{fig:IM}
+        Example isolation-with-migration Demes model. (A) The Human Data Model
+        representation expressed using YAML.
+        (B) A visual representation of the model using \texttt{demesdraw}.
+        The same model in the Machine Data Model form is provided in
+        Figure~\ref{fig:IM-MDM}.
+        The YAML descriptions in (A) and Figure~\ref{fig:IM-MDM} correspond
+        exactly to a JSON description, but are much more human-readable.
+    }
+\end{figure}
 
 \subsection*{Parsers}
 
@@ -762,42 +797,22 @@ description of the demography.
 \label{sec:appendix-figures}
 
 \begin{figure}[h!]
-    \begin{minipage}{0.44\textwidth}
-    \begin{subfigure}{\textwidth}
-    \caption{}
-        \begin{tcolorbox}
-            \inputminted[fontsize=\scriptsize,linenos,numbersep=5pt]{yaml}{models/IM.yaml}
-        \end{tcolorbox}
-    \end{subfigure}
-    \begin{subfigure}{\textwidth}
-    \caption{}
-        \begin{tcolorbox}
-            \includegraphics[width=\textwidth]{fig/IM}
-        \end{tcolorbox}
-    \end{subfigure}
-    \end{minipage}\hfill
-    \begin{minipage}{0.54\textwidth}
-    \begin{subfigure}{\textwidth}
-    \caption{}
-        \begin{tcolorbox}
-            \inputminted[fontsize=\scriptsize,linenos,numbersep=5pt]{yaml}{models/IM-resolved.yaml}
-        \end{tcolorbox}
-    \end{subfigure}
-    \end{minipage}\\
+    \begin{tcolorbox}
+        \inputminted[fontsize=\scriptsize,numbersep=5pt]{yaml}{models/IM-resolved.yaml}
+    \end{tcolorbox}
     \caption{
-        \label{fig:IM}
-        Example isolation-with-migration Demes model. (A) The Human Data Model
-        representation expressed using YAML.
-        (B) A visual representation of the model using \texttt{demesdraw}.
-        (C) The same model in the Machine Data Model form.
-        The YAML descriptions in (A) and (C) correspond exactly to a JSON description,
-        but are much more human-readable.
+        \label{fig:IM-MDM}
+        Isolation-with-migration example model from Figure~\ref{fig:IM}
+        in Machine Data Model (MDM) form.
+        The MDM form of the model is complete and explicit, but contains
+        much redundant information that is omitted in the Human Data Model
+        (HDM) form.
     }
 \end{figure}
 
 \begin{figure}[h!]
     \begin{tcolorbox}
-        \inputminted[fontsize=\scriptsize,linenos,numbersep=5pt]{yaml}{models/tennessen.yaml}
+        \inputminted[fontsize=\scriptsize,numbersep=5pt]{yaml}{models/tennessen.yaml}
     \end{tcolorbox}
     \caption{
         \textbf{The \citet{tennessen2012evolution} two-population
@@ -814,7 +829,7 @@ description of the demography.
 \begin{figure}[h!]
     \begin{tcolorbox}
         % NOTE: line highlights may need adjusting after changing this code
-        \inputminted[fontsize=\scriptsize,linenos,numbersep=5pt,highlightlines={9,19,52}]{python}{models/tennessen-simulation.py}
+        \inputminted[fontsize=\scriptsize,numbersep=5pt,highlightlines={9,19,52}]{python}{models/tennessen-simulation.py}
     \end{tcolorbox}
     \caption{
         \textbf{Simulation of SFS for the Tennessen model.}


### PR DESCRIPTION
See #77. Some text still needs to be added to the new section.

I also
* removed the line numbers, as we don't refer to them
  anywhere and I think this looks less cluttered, and
* improved consistency betwee HDM and MDM yaml in regard
  to indentation and using yaml block style.