### PR TITLE
Fix build and trim MSMC text

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -39,6 +39,7 @@
 \newcommand{\slim}[0]{\texttt{SLiM}}
 \newcommand{\gadma}[0]{\texttt{GADMA}}
 \newcommand{\tskit}[0]{\texttt{tskit}}
+\newcommand{\MSMC}[0]{\texttt{MSMC}}
 \newcommand{\demesslim}[0]{\texttt{demes-slim}}
 
 \newcommand{\aprcomment}[1]{{\textcolor{blue}{APR: #1}}}
@@ -281,7 +282,9 @@ These basic assumptions of discrete Wright-Fisher populations connected by
 instantaneous or continuous
 migrations are shared by many inference methods
 \citep[e.g.,][]{gutenkunst2009inferring,li2011inference,
-gravel2012population,kamm2017efficient,
+gravel2012population,
+SchiffelsDurbin2014,
+kamm2017efficient,
 jouganous2017inferring,ragsdale2019models,
 excoffier2021fastsimcoal2}, and
 forwards- and backwards-time simulators~\citep[e.g.,][]{hudson2002generating,

--- a/software-table.tex
+++ b/software-table.tex
@@ -48,7 +48,8 @@
     \citep{jouganous2017inferring,ragsdale2019models}. Models to be optimized can be specified in Demes.\\
 
 \MSMC & A script provided in the MSMC-tools repository \url{https://github.com/stschiff/msmc-tools}
-    converts MSMC \citep{SchiffelsDurbin2014,WangSchiffels2020} output to the demes format. Instructions are available in the Guide \url{https://github.com/stschiff/msmc-tools/blob/master/msmc-tutorial/guide.md}.\\
+    converts MSMC \citep{SchiffelsDurbin2014,WangSchiffels2020} output to the demes format. 
+\\
 
 \msprime &
     Simulates population genetic models using tree sequences~\citep{kelleher2016efficient,kelleher2020coalescent,baumdicker2021-iu}. Demographic history models can be specified using Demes.\\


### PR DESCRIPTION
Removed "documentation" link because none of the other methods have this.

Also add MSMC to list of inference method refs.